### PR TITLE
Fix oneoff arg

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,4 +11,4 @@ OCTOPUS_LOGIN_PASSWD = os.getenv("OCTOPUS_LOGIN_PASSWD", "")
 EXECUTION_TIME = os.getenv("EXECUTION_TIME", "23:00")
 
 # Whether to just run immediately and exit
-ONE_OFF_RUN = os.getenv("ONE_OFF", False)
+ONE_OFF_RUN = os.getenv("ONE_OFF", "false") in ["true", "True", "1"]


### PR DESCRIPTION
Environment variables are always strings, not bools. So this just checks whether the input string is a variant of a true boolean representation.