### PR TITLE
Reduce docker image size

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,7 +1,27 @@
-FROM mcr.microsoft.com/playwright/python:v1.49.1-noble
-
+#--- Builder Image ---
+FROM python:3.12-bookworm AS builder
 WORKDIR /app
 COPY . /app
-RUN pip install --no-cache-dir -r requirements.txt
 
-CMD ["python", "scheduler.py"]
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libfontconfig1 \
+    chromium \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies in a virtual environment
+RUN python -m venv .venv && \
+    . .venv/bin/activate && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Install Playwright
+RUN . .venv/bin/activate && playwright install --with-deps
+
+#--- Final Image ---
+FROM python:3.12-slim-bookworm
+WORKDIR /app
+COPY --from=builder /app/scheduler.py /app/scheduler.py
+COPY --from=builder /app/config.py /app/config.py
+COPY --from=builder /app/main.py /app/main.py
+COPY --from=builder /app/.venv ./.venv
+CMD [".venv/bin/python", "scheduler.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 gql==3.5.0
-playwright==1.49.1
+playwright==1.50.0
 Requests==2.32.3
 aiohttp==3.11.11


### PR DESCRIPTION
This PR refactors the Dockerfile to implement a multi-stage build, drastically reducing the final image size from 3.64GB to approximately 416MB.