### PR TITLE
Small Refactor For the REST API Calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+.DS_Store

--- a/main.py
+++ b/main.py
@@ -184,27 +184,27 @@ def get_acc_info():
     return current_tariff, curr_stdn_charge, region_code, consumption
 
 
-def get_potential_tariff_rates(tariff_short_code, region_code):
+def get_potential_tariff_rates(tariff, region_code):
     all_products = rest_query(f"{config.BASE_URL}/products/?brand=OCTOPUS_ENERGY&is_business=false")
 
     # Get the required tariff from the results
-    tariff_result = next((
+    tariff_code = next((
         product for product in all_products.get('results', [])
-        if product.get('display_name') == ("Agile Octopus" if tariff_short_code == "AGILE" else "Octopus Go")
+        if product.get('display_name') == tariff
            and product.get('direction') == "IMPORT"
     ), None)
 
-    if not tariff_result:
-        raise ValueError(f"Tariff not found for {tariff_short_code}")
+    if not tariff_code:
+        raise ValueError(f"No matching tariff found for {tariff}")
 
     # Use the self links to navigate to the tariff details
     tariff_self_link = next((
-        item.get('href') for item in tariff_result.get('links', [])
+        item.get('href') for item in tariff_code.get('links', [])
         if item.get('rel', '').lower() == 'self'
     ), None)
 
     if not tariff_self_link:
-        raise ValueError(f"Self link not found for tariff {tariff_result.get('code', 'Unknown')}.")
+        raise ValueError(f"Self link not found for tariff {tariff_code.get('code', 'Unknown')}.")
 
     tariff_details = rest_query(tariff_self_link)
 

--- a/tariff.py
+++ b/tariff.py
@@ -1,3 +1,5 @@
+import re
+
 class Tariff:
     def __init__(self,
                  id: str, display_name: str, api_display_name: str, tariff_code_matcher: str,
@@ -10,8 +12,8 @@ class Tariff:
         self.switchable = switchable  # Whether this tariff can be switched to or not
 
     def is_tariff(self, current_tariff_name: str) -> bool:
-        """Check if the given tariff name matches the tariff code matcher."""
-        return self.tariff_code_matcher.lower() in current_tariff_name.lower()
+        """Check if the given tariff name matches the tariff code matcher using regex."""
+        return re.search(self.tariff_code_matcher, current_tariff_name,  re.IGNORECASE) is not None
 
     def __eq__(self, other):
         """Compare two tariffs based on their ID."""
@@ -27,8 +29,8 @@ class Tariff:
 
 
 TARIFFS = [
-    Tariff("go", "Octopus Go", "Octopus Go", "go", "go", True), # Octopus Go
-    Tariff("agile", "Agile Octopus", "Agile Octopus", "agile", "agile", True), # Octopus Agile
-    Tariff("cosy", "Cosy Octopus", "Cosy Octopus", "cosy", "cosy-octopus", True), # Octopus Cosy
-    Tariff("flexible", "Flexible Octopus", "Flexible Octopus", "var", "", False) # Flexible Octopus
+    Tariff("go", "Octopus Go", "Octopus Go", r"-go-", "go", True), # Octopus Go
+    Tariff("agile", "Agile Octopus", "Agile Octopus", r"-agile-", "agile", True), # Octopus Agile
+    Tariff("cosy", "Cosy Octopus", "Cosy Octopus", r"-cosy-", r"cosy-octopus", True), # Octopus Cosy
+    Tariff("flexible", "Flexible Octopus", "Flexible Octopus", r"(?<!go-)var", "", False) # Flexible Octopus
 ]


### PR DESCRIPTION
I have made a small change to avoid user error to

- use the links from the responses in the REST API calls to navigate 
- this is instead of crafting the urls manually
- this will work for all regions and all tariffs
- fixes small bug in tariff detection in https://github.com/eelmafia/octopus-minmax/pull/39
- tested locally and works well

![Screenshot 2025-03-02 at 11 49 36](https://github.com/user-attachments/assets/685b8083-6bb1-4660-ace3-c1ebb2ae15c7)