### PR TITLE
Fetch terms version before attempting to accept new agreement

### DIFF
--- a/account_info.py
+++ b/account_info.py
@@ -2,8 +2,9 @@ from tariff import Tariff
 
 
 class AccountInfo:
-    def __init__(self, current_tariff: Tariff, standing_charge: float, region_code: str, consumption):
+    def __init__(self, current_tariff: Tariff, standing_charge: float, region_code: str, consumption, product_code: str):
         self.current_tariff = current_tariff
         self.standing_charge = standing_charge
         self.region_code = region_code
         self.consumption = consumption
+        self.product_code = product_code

--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ def get_terms_version(product_code):
 
     return({'major': int(terms_version[0]), 'minor': int(terms_version[1])})
 
-def accept_new_agreement():
+def accept_new_agreement(product_code):
     query = gql(enrolment_query.format(acc_number=config.ACC_NUMBER))
     result = gql_client.execute(query)
     try:
@@ -74,7 +74,12 @@ def accept_new_agreement():
                         return
 
         raise Exception("ERROR: No completed post-enrolment found today and no in-progress enrolment.")
-    query = gql(accept_terms_query.format(account_number=config.ACC_NUMBER, enrolment_id=enrolment_id))
+    
+    version = get_terms_version(product_code)
+    query = gql(accept_terms_query.format(account_number=config.ACC_NUMBER, 
+                                          enrolment_id=enrolment_id,
+                                          version_major=version['major'],
+                                          version_minor=version['minor']))
     result = gql_client.execute(query)
 
 
@@ -344,7 +349,7 @@ def compare_and_switch():
         send_notification("Tariff switch requested successfully.")
         # Give octopus some time to generate the agreement
         time.sleep(60)
-        accept_new_agreement()
+        accept_new_agreement(account_info.product_code)
         send_notification("Accepted agreement. Switch successful.")
 
         if verify_new_agreement():

--- a/main.py
+++ b/main.py
@@ -47,6 +47,13 @@ def send_notification(message, title="Octobot"):
 
     apprise.notify(body=message, title=title)
 
+# The version of the terms and conditions is required to accept the new tariff
+def get_terms_version(product_code):
+    query = gql(get_terms_version_query.format(product_code=product_code))
+    result = gql_client.execute(query)
+    terms_version = result.get('termsAndConditionsForProduct', {}).get('version', "1.0").split('.')
+
+    return({'major': int(terms_version[0]), 'minor': int(terms_version[1])})
 
 def accept_new_agreement():
     query = gql(enrolment_query.format(acc_number=config.ACC_NUMBER))
@@ -78,6 +85,9 @@ def get_acc_info() -> AccountInfo:
     tariff_code = next(agreement['tariff']['tariffCode']
                        for agreement in result['account']['electricityAgreements']
                        if 'tariffCode' in agreement['tariff'])
+    product_code = next(agreement['tariff']['productCode']
+                        for agreement in result['account']['electricityAgreements']
+                        if 'productCode' in agreement['tariff'])
     region_code = tariff_code[-1]
     device_id = next(device['deviceId']
                      for agreement in result['account']['electricityAgreements']
@@ -98,7 +108,7 @@ def get_acc_info() -> AccountInfo:
                                      end_date=f"{date.today()}T23:59:59Z")))
     consumption = result['smartMeterTelemetry']
 
-    return AccountInfo(matching_tariff, curr_stdn_charge, region_code, consumption)
+    return AccountInfo(matching_tariff, curr_stdn_charge, region_code, consumption, product_code)
 
 
 def get_potential_tariff_rates(tariff, region_code):

--- a/queries.py
+++ b/queries.py
@@ -4,19 +4,27 @@ token_query = """mutation {{
 	}}
 }}"""
 
-# I have no idea if versionMajor or versionMinor has an impact???
 accept_terms_query = """mutation {{
     acceptTermsAndConditions(input: {{
         accountNumber: "{account_number}",
         enrolmentId: "{enrolment_id}",
         termsVersion: {{
-            versionMajor: 1,
-            versionMinor: 1
+            versionMajor: {version_major},
+            versionMinor: {version_minor}
         }}
     }}) 
     {{
     acceptedVersion
   }}
+}}"""
+
+get_terms_version_query = """query {{
+    termsAndConditionsForProduct(productCode: "{product_code}") {{
+        name
+        pdfUrl
+        version
+        effectiveFrom
+    }}
 }}"""
 
 consumption_query = """query {{


### PR DESCRIPTION
Now fetches the newest version of the TnC agreement before attempting to accept. This should ensure that a valid TnC agreement is accepted.

In case it cannot fetch the terms version via the API it uses `1.0` as a fallback which may cause problems in the future if that version becomes deprecated. `1.0` is a valid TnC version as of this PR.

Closes https://github.com/eelmafia/octopus-minmax/issues/38