### PR TITLE
Switch_today

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,11 @@
 import time
 import traceback
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 
 import requests
 from apprise import Apprise
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
-#from playwright.sync_api import sync_playwright
 
 import config
 from account_info import AccountInfo
@@ -204,8 +203,7 @@ def get_token():
 
 
 def switch_tariff(target_product_code, mpan):
-    # Note that we must use tomorrow's date but the switch can (will) happen today
-    change_date = date.today() + timedelta(days=1)
+    change_date = date.today()
     query = gql(switch_query.format(account_number=config.ACC_NUMBER, mpan=mpan, product_code=target_product_code, change_date=change_date))
     result = gql_client.execute(query)
     return result.get("startOnboardingProcess", {}).get("productEnrolment", {}).get("id")


### PR DESCRIPTION
## Switch using today instead of tomorrow's date. 

* fix StopIteration error when ValidFro not present
* try verification one more time after 20s if verification failed.

As discussed in #53, The docs for [StartSmartOnboardingProcessInput](https://developer.octopus.energy/graphql/reference/input-objects#api-io-startsmartonboardingprocessinput) state you could use today's date.

Switched today (using today's) date and got a `StopIteration` in `verify_new_agreement()` because there was no `validFrom` in the response --> _add default value to the iterator._

a second try to verify was successful --> _add 2nd try in code and improve error messages._ 