### PR TITLE
Remove backticks from notifications, wrap errors in codeblocks, and make notifications clearer

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,12 +18,13 @@ gql_client: Client
 tariffs = []
 
 
-def send_notification(message, title="Octobot"):
+def send_notification(message, title="", error=False):
     """Sends a notification using Apprise.
 
     Args:
         message (str): The message to send.
-        title (str, optional): The title of the notification. Defaults to "Octobot".
+        title (str, optional): The title of the notification.
+        error (bool, optional): Whether the message is a stack trace. Defaults to False.
     """
     print(message)
 
@@ -37,12 +38,8 @@ def send_notification(message, title="Octobot"):
         print("No notification services configured. Check config.NOTIFICATION_URLS.")
         return
 
-    # Check if any of the URLs are Discord URLs, and only wrap the message in backticks if *only* Discord is present
-    urls = config.NOTIFICATION_URLS.split(',') if config.NOTIFICATION_URLS else []  # Get the URLs, handle None
-    is_only_discord = all("discord" in url.lower() for url in urls)
-
-    if is_only_discord:
-        message = f"`{message}`"
+    if error:
+        message = f"```py\n{message}\n```"
 
     apprise.notify(body=message, title=title)
 
@@ -231,7 +228,7 @@ def setup_gql(token):
 
 def compare_and_switch():
     welcome_message = "DRY RUN: " if config.DRY_RUN else ""
-    welcome_message += "Octobot on. Starting comparison of today's costs..."
+    welcome_message += "Starting comparison of today's costs..."
     send_notification(welcome_message)
 
     account_info = get_acc_info()
@@ -368,4 +365,4 @@ def run_tariff_compare():
         else:
             raise Exception("ERROR: setup_gql has failed")
     except Exception:
-        send_notification(traceback.format_exc())
+        send_notification(message=traceback.format_exc(), title="Octobot Error", error=True)

--- a/scheduler.py
+++ b/scheduler.py
@@ -2,16 +2,16 @@ import time
 from datetime import datetime
 import random
 import config
-from main import run_tariff_compare
+from main import run_tariff_compare, send_notification
 
 # Track last execution date to ensure we only run once per day
 last_execution_date = None
 
 if config.ONE_OFF_RUN:
-    print(f"Welcome to Octopus MinMax Bot. Executing a one off comparison.")
+    send_notification(message="Octobot on. Running a one off comparison.")
     run_tariff_compare()
 else:
-    print(f"Welcome to Octopus MinMax Bot. I will run your comparisons at {config.EXECUTION_TIME}")
+    send_notification(message=f"Welcome to Octopus MinMax Bot. I will run your comparisons at {config.EXECUTION_TIME}")
 
     while True:
         now = datetime.now()
@@ -19,9 +19,11 @@ else:
         current_date = now.date()
 
         if current_time == config.EXECUTION_TIME and last_execution_date != current_date:
-            print(f"Executing tariff comparison at {current_time}...")
             last_execution_date = current_date
-            time.sleep(random.randint(10,600)) #10 Sec - 10 Min Random Delay to prevent all users attempting to access API at same time
+            # 10 Sec - 10 Min Random Delay to prevent all users attempting to access API at same time
+            delay = random.randint(10,600) 
+            send_notification(message=" Octobot on. Initiating comparison in {:.1f} minutes".format(delay/60))
+            delay = time.sleep(delay)
             run_tariff_compare()
 
         time.sleep(30)  # Check time every 30 seconds


### PR DESCRIPTION
- `send_notifications` now defaults to no title and wraps stack traces in a codeblock. Discord messages are no longer wrapped in backticks. 
- Replaced `print` statements in `scheduler.py` with `send_notification` for better clarity

Closes https://github.com/eelmafia/octopus-minmax/issues/48