### PR TITLE
Restore legacy:true to config.yaml (fixes #141)

### DIFF
--- a/octopus_minmax_bot_addon/config.yaml
+++ b/octopus_minmax_bot_addon/config.yaml
@@ -13,6 +13,7 @@ version: v1.0.5
 slug: octopus_minmax_bot
 startup: application
 init: false
+legacy: true
 description: A bot to automatically compare and switch smart electricity tariffs on Octopus Energy
 arch:
   - armhf


### PR DESCRIPTION
Fixes #141

**Description:**
Home Assistant addons dump their config into /data/options.json (inside the container) - I'm not sure if they should automatically be exposed as environment variables but they aren't and as such the app receives none.

This fix simply loads the content of /data/options.json into environment variables and then the rest of the app works as normal.

**Evidence:**

Logs from the add-on showing successful execution - no errors about notifications etc:
<img width="1408" height="586" alt="image" src="https://github.com/user-attachments/assets/5c6a6510-49ef-4ab0-a005-ea6facd19545" />

Logs from inside the app - same as above:
<img width="1172" height="734" alt="image" src="https://github.com/user-attachments/assets/cc07ef36-039b-457b-b637-e2bba1e895ed" />
