### PR TITLE
Add optional comparison chart to notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ docker run -d \
   -e TARIFFS=go,agile,flexible \
   -e TZ=Europe/London \
   -e BATCH_NOTIFICATIONS=false \
+  -e SEND_COMPARISON_CHART=true \
   -e WEB_USERNAME="<whatever_you_want>" \
   -e WEB_PASSWORD="<whatever_you_want>" \
   eelmafia/octopus-minmax-bot
@@ -84,6 +85,7 @@ Note : Remove the --restart unless line if you set the ONE_OFF variable or it wi
 | `ONE_OFF`                   | (Optional) A flag for you to simply trigger an immediate execution instead of starting scheduling.                                                                                                                      |
 | `DRY_RUN`                   | (Optional) A flag to compare but not switch tariffs.                                                                                                                                                                    |
 | `BATCH_NOTIFICATIONS`       | (Optional) A flag to send messages in one batch rather than individually.                                                                                                                                               |
+| `SEND_COMPARISON_CHART`     | (Optional) Attach a stacked standing-charge vs usage chart to the daily notification. Default is `true`.                                                                                                                |
 | `WEB_USERNAME`              | (Optional) Defaults to `admin`. Auth for the web dashboard.
 | `WEB_PASSWORD`              | (Optional) Defaults to `admin`. Auth for the web dashboard.
 | `WEB_PORT`                  | (Optional) Defaults to `5050`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - NOTIFICATION_URLS=<your_apprise_notification_urls>
       - ONE_OFF=false
       - DRY_RUN=false
+      - SEND_COMPARISON_CHART=true
       - TARIFFS=agile,flexible
       - WEB_USERNAME=admin
       - WEB_PASSWORD=admin # not meant to be secure

--- a/dockerfile
+++ b/dockerfile
@@ -2,6 +2,7 @@ FROM python:3.9-slim
 
 WORKDIR /app
 COPY . /app
+RUN pip install --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir -r requirements.txt
 RUN mkdir -p /app/logs
 EXPOSE 5050

--- a/octopus_minmax_bot_addon/README.md
+++ b/octopus_minmax_bot_addon/README.md
@@ -64,6 +64,7 @@ docker run -d \
   -e TARIFFS=go,agile,flexible \
   -e TZ=Europe/London \
   -e BATCH_NOTIFICATIONS=false \
+  -e SEND_COMPARISON_CHART=true \
   -e WEB_USERNAME="<whatever_you_want>" \
   -e WEB_PASSWORD="<whatever_you_want>" \
   eelmafia/octopus-minmax-bot
@@ -84,6 +85,7 @@ Note : Remove the --restart unless line if you set the ONE_OFF variable or it wi
 | `ONE_OFF`                   | (Optional) A flag for you to simply trigger an immediate execution instead of starting scheduling.                                                                                                                      |
 | `DRY_RUN`                   | (Optional) A flag to compare but not switch tariffs.                                                                                                                                                                    |
 | `BATCH_NOTIFICATIONS`       | (Optional) A flag to send messages in one batch rather than individually.                                                                                                                                               |
+| `SEND_COMPARISON_CHART`     | (Optional) Attach a stacked standing-charge vs usage chart to the daily notification. Default is `true`.                                                                                                                |
 | `WEB_USERNAME`              | (Optional) Defaults to `admin`. Auth for the web dashboard.
 | `WEB_PASSWORD`              | (Optional) Defaults to `admin`. Auth for the web dashboard.
 | `WEB_PORT`                  | (Optional) Defaults to `5050`.

--- a/octopus_minmax_bot_addon/config.yaml
+++ b/octopus_minmax_bot_addon/config.yaml
@@ -31,6 +31,7 @@ options:
   TARIFFS: "agile,go,flexible"
   TZ: "Europe/London"
   BATCH_NOTIFICATIONS: false
+  SEND_COMPARISON_CHART: true
   WEB_USERNAME: "admin"
   WEB_PASSWORD: "admin"
 schema:
@@ -44,5 +45,6 @@ schema:
   TARIFFS: str
   TZ: str
   BATCH_NOTIFICATIONS: bool
+  SEND_COMPARISON_CHART: bool
   WEB_USERNAME: str
   WEB_PASSWORD: password

--- a/octopus_minmax_bot_addon/translations/en.yaml
+++ b/octopus_minmax_bot_addon/translations/en.yaml
@@ -30,3 +30,6 @@ configuration:
   BATCH_NOTIFICATIONS:
     name: Batch Notifications
     description: An optional flag to send messages in one batch rather than individually
+  SEND_COMPARISON_CHART:
+    name: Send Comparison Chart
+    description: Attach a stacked standing-charge vs usage chart to the daily notification. Turn off to send text only.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ Requests==2.32.3
 aiohttp==3.11.11
 apprise==1.9.2
 Flask==3.1.0
+matplotlib==3.9.4
+numpy==2.0.2
+pillow==10.4.0

--- a/src/bot_orchestrator.py
+++ b/src/bot_orchestrator.py
@@ -10,6 +10,7 @@ from tariff import Tariff, TARIFFS
 from query_service import QueryService
 from comparison_engine import ComparisonEngine, ComparisonResult
 from notification_service import NotificationService
+from chart import create_tariff_comparison_chart
 import logging
 logger = logging.getLogger('octobot.bot_orchestrator')
 
@@ -125,6 +126,13 @@ class BotOrchestrator:
 
         summary = self._format_comparison_summary(results)
         ns.send_notification(message=summary)
+        try:
+            cost_chart = create_tariff_comparison_chart(results)
+        except Exception as e:
+            logger.warning(f"Failed to create comparison chart: {e}")
+            cost_chart = None
+        if cost_chart:
+            ns.send_notification(message="Tariff comparison chart", image_path=cost_chart, batchable=False)
 
         if results.should_switch:
             switch_message = f"Initiating Switch to {results.cheapest_tariff.display_name}"

--- a/src/bot_orchestrator.py
+++ b/src/bot_orchestrator.py
@@ -133,7 +133,7 @@ class BotOrchestrator:
                 logger.warning(f"Failed to create comparison chart: {e}")
                 cost_chart = None
             if cost_chart:
-                ns.send_notification(message="Tariff comparison chart", image_path=cost_chart, batchable=False)
+                ns.send_notification(message="", image_path=cost_chart, batchable=False)
 
         if results.should_switch:
             switch_message = f"Initiating Switch to {results.cheapest_tariff.display_name}"

--- a/src/bot_orchestrator.py
+++ b/src/bot_orchestrator.py
@@ -126,13 +126,14 @@ class BotOrchestrator:
 
         summary = self._format_comparison_summary(results)
         ns.send_notification(message=summary)
-        try:
-            cost_chart = create_tariff_comparison_chart(results)
-        except Exception as e:
-            logger.warning(f"Failed to create comparison chart: {e}")
-            cost_chart = None
-        if cost_chart:
-            ns.send_notification(message="Tariff comparison chart", image_path=cost_chart, batchable=False)
+        if config.SEND_COMPARISON_CHART:
+            try:
+                cost_chart = create_tariff_comparison_chart(results)
+            except Exception as e:
+                logger.warning(f"Failed to create comparison chart: {e}")
+                cost_chart = None
+            if cost_chart:
+                ns.send_notification(message="Tariff comparison chart", image_path=cost_chart, batchable=False)
 
         if results.should_switch:
             switch_message = f"Initiating Switch to {results.cheapest_tariff.display_name}"

--- a/src/chart.py
+++ b/src/chart.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Optional
+from typing import Optional, Sequence
 
 import matplotlib
 matplotlib.use("Agg")
@@ -10,12 +10,118 @@ from comparison_engine import ComparisonResult
 
 logger = logging.getLogger("octobot.chart")
 
+STANDING_COLOR = "#9A3B3B"
+CONSUMPTION_COLOR = "#632626"
+
 
 def _chart_path() -> str:
     for directory in ("/data", "/app/logs", "/tmp"):
         if os.path.isdir(directory) and os.access(directory, os.W_OK):
             return os.path.join(directory, "tariff_comparison.jpg")
     return "/tmp/tariff_comparison.jpg"
+
+
+def _pounds(value: float) -> str:
+    return f"£{value:.2f}"
+
+
+def _label(ax, x: float, y: float, text: str, va: str = "center", ha: str = "center") -> None:
+    ax.text(x, y, text, ha=ha, va=va, color="white", fontsize=9, clip_on=True)
+
+
+def _draw_cost_bars(
+    ax,
+    labels: Sequence[str],
+    standing_charges: Sequence[float],
+    consumption_costs: Sequence[float],
+    total_costs: Sequence[float],
+) -> None:
+    xs = list(range(len(labels)))
+    has_negative_total = any(total < 0 for total in total_costs)
+
+    standing_bars = ax.bar(xs, standing_charges, color=STANDING_COLOR, zorder=2)
+
+    positive_consumption = [cost if cost > 0 else 0 for cost in consumption_costs]
+    ax.bar(xs, positive_consumption, bottom=standing_charges, color=CONSUMPTION_COLOR, zorder=3)
+
+    hatch_heights = []
+    hatch_bottoms = []
+    below_zero = []
+    for standing, consumption, total in zip(standing_charges, consumption_costs, total_costs):
+        if consumption >= 0:
+            hatch_heights.append(0)
+            hatch_bottoms.append(0)
+            below_zero.append(0)
+            continue
+        # Hatch the standing charge from the net remainder (or 0) up to the full S/C.
+        hatch_bottom = max(total, 0)
+        hatch_heights.append(max(standing - hatch_bottom, 0))
+        hatch_bottoms.append(hatch_bottom)
+        below_zero.append(total if total < 0 else 0)
+
+    ax.bar(
+        xs,
+        hatch_heights,
+        bottom=hatch_bottoms,
+        facecolor=CONSUMPTION_COLOR,
+        edgecolor="white",
+        hatch="///",
+        linewidth=0.6,
+        zorder=4,
+    )
+    ax.bar(xs, below_zero, color=CONSUMPTION_COLOR, zorder=3)
+
+    visual_tops = [standing + max(consumption, 0) for standing, consumption in zip(standing_charges, consumption_costs)]
+    visual_bottoms = [min(0, total) for total in total_costs]
+    y_max = max(visual_tops) if visual_tops else 1
+    y_min = min(visual_bottoms) if visual_bottoms else 0
+    headroom = max(abs(y_max) * 0.22, abs(y_min) * 0.35, 0.18)
+    ax.set_ylim(y_min - (headroom if y_min < 0 else 0), y_max + headroom)
+    span = ax.get_ylim()[1] - ax.get_ylim()[0]
+    min_inside = span * 0.08
+    total_offset = span * 0.04
+
+    if has_negative_total or any(cost < 0 for cost in consumption_costs):
+        ax.axhline(0, color="white", linewidth=0.8, zorder=1)
+
+    for x, bar, standing, consumption, total, hatch_h, hatch_b in zip(
+        xs, standing_bars, standing_charges, consumption_costs, total_costs, hatch_heights, hatch_bottoms
+    ):
+        cx = bar.get_x() + bar.get_width() / 2
+        if consumption >= 0:
+            if standing >= min_inside:
+                _label(ax, cx, standing / 2, _pounds(standing))
+            if consumption >= min_inside:
+                _label(ax, cx, standing + consumption / 2, _pounds(consumption))
+            _label(ax, cx, total + total_offset, _pounds(total), va="bottom")
+            continue
+
+        remainder = hatch_b  # unhatched S/C when total > 0, else 0
+        if remainder >= min_inside:
+            _label(ax, cx, remainder / 2, _pounds(standing))
+        elif standing >= min_inside:
+            _label(ax, cx, standing / 2, _pounds(standing))
+
+        if total < 0:
+            if abs(total) >= min_inside:
+                _label(ax, cx, total / 2, _pounds(consumption))
+            elif hatch_h >= min_inside:
+                _label(ax, cx, hatch_b + hatch_h / 2, _pounds(consumption))
+            else:
+                _label(ax, cx + 0.42, (total / 2) if total else standing / 2, _pounds(consumption), ha="left")
+            _label(ax, cx, total - total_offset, _pounds(total), va="top")
+        else:
+            if hatch_h >= min_inside:
+                _label(ax, cx, hatch_b + hatch_h / 2, _pounds(consumption))
+            elif hatch_h > 0:
+                _label(ax, cx + 0.42, hatch_b + hatch_h / 2, _pounds(consumption), ha="left")
+            _label(ax, cx, standing + total_offset, _pounds(total), va="bottom")
+
+    ax.set_ylabel("Cost (£)", color="white")
+    ax.set_xticks(xs)
+    ax.set_xticklabels(list(labels), rotation=45, ha="right", color="white")
+    ax.tick_params(colors="white")
+    ax.grid(False, axis="x")
 
 
 def create_tariff_comparison_chart(result: ComparisonResult) -> Optional[str]:
@@ -34,34 +140,15 @@ def create_tariff_comparison_chart(result: ComparisonResult) -> Optional[str]:
     fig, ax = plt.subplots(figsize=(8, 6))
     fig.patch.set_facecolor("#121212")
     ax.set_facecolor("#121212")
-    bars_standing = ax.bar(labels, standing_charges, color="#9A3B3B")
-    ax.bar(labels, consumption_costs, bottom=standing_charges, color="#632626")
-
-    for bar, standing, consumption in zip(bars_standing, standing_charges, consumption_costs):
-        ax.text(bar.get_x() + bar.get_width() / 2, standing / 2, f"£{standing:.2f}", ha="center", color="white")
-        ax.text(
-            bar.get_x() + bar.get_width() / 2,
-            standing + consumption / 2,
-            f"£{consumption:.2f}",
-            ha="center",
-            color="white",
-        )
-
-    for bar, total in zip(bars_standing, total_costs):
-        ax.text(bar.get_x() + bar.get_width() / 2, total + 0.05, f"£{total:.2f}", ha="center", color="white")
-
-    ax.set_ylabel("Cost (£)", color="white")
-    plt.xticks(rotation=45, ha="right", color="white")
-    plt.yticks(color="white")
-    ax.grid(False, axis="x")
+    _draw_cost_bars(ax, labels, standing_charges, consumption_costs, total_costs)
     plt.tight_layout()
 
     path = _chart_path()
     try:
-        fig.savefig(path, format="jpeg", dpi=120, facecolor=fig.get_facecolor(), bbox_inches="tight")
+        fig.savefig(path, format="jpeg", dpi=120, facecolor=fig.get_facecolor(), bbox_inches="tight", pad_inches=0.15)
     except ValueError:
         path = os.path.splitext(path)[0] + ".png"
-        fig.savefig(path, format="png", dpi=120, facecolor=fig.get_facecolor(), bbox_inches="tight")
+        fig.savefig(path, format="png", dpi=120, facecolor=fig.get_facecolor(), bbox_inches="tight", pad_inches=0.15)
     plt.close(fig)
 
     size = os.path.getsize(path) if os.path.isfile(path) else 0

--- a/src/chart.py
+++ b/src/chart.py
@@ -1,0 +1,73 @@
+import logging
+import os
+from typing import Optional
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from comparison_engine import ComparisonResult
+
+logger = logging.getLogger("octobot.chart")
+
+
+def _chart_path() -> str:
+    for directory in ("/data", "/app/logs", "/tmp"):
+        if os.path.isdir(directory) and os.access(directory, os.W_OK):
+            return os.path.join(directory, "tariff_comparison.jpg")
+    return "/tmp/tariff_comparison.jpg"
+
+
+def create_tariff_comparison_chart(result: ComparisonResult) -> Optional[str]:
+    """Render a stacked bar chart of standing charge vs consumption cost per tariff."""
+    valid = [comparison for comparison in result.all_comparisons if comparison.is_valid]
+    if not valid:
+        logger.warning("No valid tariff comparisons available to chart")
+        return None
+
+    labels = [comparison.tariff.display_name for comparison in valid]
+    standing_charges = [comparison.cost_breakdown.standing_charge_pounds for comparison in valid]
+    consumption_costs = [comparison.cost_breakdown.consumption_cost_pounds for comparison in valid]
+    total_costs = [comparison.cost_breakdown.total_cost_pounds for comparison in valid]
+
+    plt.style.use("dark_background")
+    fig, ax = plt.subplots(figsize=(8, 6))
+    fig.patch.set_facecolor("#121212")
+    ax.set_facecolor("#121212")
+    bars_standing = ax.bar(labels, standing_charges, color="#9A3B3B")
+    ax.bar(labels, consumption_costs, bottom=standing_charges, color="#632626")
+
+    for bar, standing, consumption in zip(bars_standing, standing_charges, consumption_costs):
+        ax.text(bar.get_x() + bar.get_width() / 2, standing / 2, f"£{standing:.2f}", ha="center", color="white")
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            standing + consumption / 2,
+            f"£{consumption:.2f}",
+            ha="center",
+            color="white",
+        )
+
+    for bar, total in zip(bars_standing, total_costs):
+        ax.text(bar.get_x() + bar.get_width() / 2, total + 0.05, f"£{total:.2f}", ha="center", color="white")
+
+    ax.set_ylabel("Cost (£)", color="white")
+    plt.xticks(rotation=45, ha="right", color="white")
+    plt.yticks(color="white")
+    ax.grid(False, axis="x")
+    plt.tight_layout()
+
+    path = _chart_path()
+    try:
+        fig.savefig(path, format="jpeg", dpi=120, facecolor=fig.get_facecolor(), bbox_inches="tight")
+    except ValueError:
+        path = os.path.splitext(path)[0] + ".png"
+        fig.savefig(path, format="png", dpi=120, facecolor=fig.get_facecolor(), bbox_inches="tight")
+    plt.close(fig)
+
+    size = os.path.getsize(path) if os.path.isfile(path) else 0
+    if size <= 0:
+        logger.error(f"Comparison chart was not written to {path}")
+        return None
+
+    logger.info(f"Wrote comparison chart ({size} bytes) to {path}")
+    return path

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,8 @@ BASE_URL = os.getenv("BASE_URL", "https://api.octopus.energy/v1")
 NOTIFICATION_URLS = os.getenv("NOTIFICATION_URLS", "")
 # Whether to send all the notifications as a batch or individually
 BATCH_NOTIFICATIONS = os.getenv("BATCH_NOTIFICATIONS", "false") in ["true", "True", "1"]
+# Whether to attach a stacked cost chart to the daily notification
+SEND_COMPARISON_CHART = os.getenv("SEND_COMPARISON_CHART", "true") in ["true", "True", "1"]
 
 EXECUTION_TIME = os.getenv("EXECUTION_TIME", "23:00")
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -19,6 +19,7 @@ def get_config():
             'dry_run': config.DRY_RUN,
             'notification_urls': config.NOTIFICATION_URLS,
             'batch_notifications': config.BATCH_NOTIFICATIONS,
+            'send_comparison_chart': config.SEND_COMPARISON_CHART,
         }
 
 
@@ -55,6 +56,10 @@ def update_config(new_values):
         else:
             # Checkbox not checked means False
             config.BATCH_NOTIFICATIONS = False
+        if 'send_comparison_chart' in new_values:
+            config.SEND_COMPARISON_CHART = str(new_values['send_comparison_chart']).lower() in ['true', '1', 'yes', 'on']
+        else:
+            config.SEND_COMPARISON_CHART = False
 
         if config.ONE_OFF_RUN and not previous_one_off:
             config.ONE_OFF_EXECUTED = False

--- a/src/logger.py
+++ b/src/logger.py
@@ -42,6 +42,12 @@ def setup_logging():
     logger.addHandler(file_handler)
     logger.addHandler(console_handler)
 
+    apprise_logger = logging.getLogger('apprise')
+    apprise_logger.setLevel(logging.INFO)
+    if not apprise_logger.handlers:
+        apprise_logger.addHandler(file_handler)
+        apprise_logger.addHandler(console_handler)
+
     return logger
 
 logger = setup_logging()

--- a/src/notification_service.py
+++ b/src/notification_service.py
@@ -77,10 +77,13 @@ class NotificationService:
                     notify_kwargs["attach"] = f"file://{abs_path}"
             success = apprise.notify(**notify_kwargs)
             if success:
-                logger.info(f"Sent notification: {message}")
+                if message:
+                    logger.info(f"Sent notification: {message}")
+                else:
+                    logger.info("Sent notification attachment")
             else:
                 logger.error(f"Failed to send notification (title={title!r}, attach={bool(image_path)})")
-                if image_path:
+                if image_path and message:
                     logger.info("Retrying notification without attachment")
                     retry_kwargs = {"body": message, "title": title}
                     success = apprise.notify(**retry_kwargs)

--- a/src/notification_service.py
+++ b/src/notification_service.py
@@ -2,6 +2,7 @@ from apprise import Apprise
 from datetime import datetime
 from typing import List, Optional
 import logging
+import os
 
 import config
 
@@ -15,6 +16,7 @@ class NotificationService:
         self.batch_notifications: List[str] = []
         self.batch_enabled = batch_enabled
         self._apprise: Optional[Apprise] = None
+        self._batch_image_path: Optional[str] = None
 
     def _refresh_from_config(self) -> None:
         if self.notification_urls != config.NOTIFICATION_URLS:
@@ -32,7 +34,7 @@ class NotificationService:
 
         return self._apprise
 
-    def send_notification(self, message:str, title: str = "", is_error: bool = False, batchable: bool = True) -> bool:
+    def send_notification(self, message:str, title: str = "", is_error: bool = False, batchable: bool = True, image_path: Optional[str] = None) -> bool:
         """Sends a notification using Apprise.
 
         Args:
@@ -40,6 +42,7 @@ class NotificationService:
             title (str, optional): The title of the notification.
             is_error (bool, optional): Whether the message is a stack trace. Defaults to False.
             batchable (bool, optional): Whether the message can be batched.
+            image_path (str, optional): Path to an image to attach.
         """
         self._refresh_from_config()
         apprise = self._get_apprise()
@@ -55,6 +58,8 @@ class NotificationService:
 
         if self.batch_enabled and batchable:
             self.batch_notifications.append(message)
+            if image_path:
+                self._batch_image_path = image_path
             logger.debug(f"Added message to batch. Current batch size: {len(self.batch_notifications)}")
             return True
         else:
@@ -62,10 +67,25 @@ class NotificationService:
                 logger.warning("No notification services configured. Check config.NOTIFICATION_URLS.")
                 logger.info(message)
                 return False
-            success = apprise.notify(body=message, title=title)
-            logger.info(f"Successfuly sent notification: {message}")
-            if not success:
-                logger.error(f"Failed to send notification: {title}")
+            notify_kwargs = {"body": message, "title": title}
+            if image_path:
+                abs_path = os.path.abspath(image_path)
+                if not os.path.isfile(abs_path):
+                    logger.error(f"Cannot attach missing file: {abs_path}")
+                else:
+                    # file:// URLs are more reliable with Apprise than raw paths.
+                    notify_kwargs["attach"] = f"file://{abs_path}"
+            success = apprise.notify(**notify_kwargs)
+            if success:
+                logger.info(f"Sent notification: {message}")
+            else:
+                logger.error(f"Failed to send notification (title={title!r}, attach={bool(image_path)})")
+                if image_path:
+                    logger.info("Retrying notification without attachment")
+                    retry_kwargs = {"body": message, "title": title}
+                    success = apprise.notify(**retry_kwargs)
+                    if success:
+                        logger.info(f"Sent notification without attachment: {message}")
             return success
 
     def send_batch_notification(self) -> bool:
@@ -84,10 +104,18 @@ class NotificationService:
             logger.warning("Cannot send batch - no notification services configured. Check config.NOTIFICATION_URLS.")
             logger.info(body)
             return False
-        success = apprise.notify(body=body, title=title)
+        notify_kwargs = {"body": body, "title": title}
+        if self._batch_image_path:
+            abs_path = os.path.abspath(self._batch_image_path)
+            if os.path.isfile(abs_path):
+                notify_kwargs["attach"] = f"file://{abs_path}"
+            else:
+                logger.error(f"Cannot attach missing file: {abs_path}")
+        success = apprise.notify(**notify_kwargs)
         if success:
             logger.info(f"Sent batch notification with {len(self.batch_notifications)} messages")
             self.batch_notifications.clear()
+            self._batch_image_path = None
         else:
             logger.error("Failed to send batch notification")
 

--- a/src/templates/config.html
+++ b/src/templates/config.html
@@ -98,6 +98,11 @@
                            class="w-5 h-5 bg-gray-900 border border-gray-600 rounded">
                     <label class="ml-3 text-gray-300" for="batch_notifications">Batch Notifications</label>
                 </div>
+                <div class="flex items-center">
+                    <input type="checkbox" id="send_comparison_chart" name="send_comparison_chart" {% if config.send_comparison_chart %}checked{% endif %}
+                           class="w-5 h-5 bg-gray-900 border border-gray-600 rounded">
+                    <label class="ml-3 text-gray-300" for="send_comparison_chart">Send comparison chart</label>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
## Send a comparison chart snapshot (stacked standing charge & usage) after the text summary.

### Summary
- After the text summary, attach a JPEG chart
- `SEND_COMPARISON_CHART` defaults on. available in the web UI
- Negative consumption is hatched over the standing charge; if it exceeds S/C the leftover goes below zero.
- This is a daily comparison chart, unrelated to #153 

Note: batch notifications mode will omit the chart

New dependencies: matplotlib + numpy + pillow

Tested on local HA + Telegram

Example (a bit old):
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/2cb18294-0cdf-47ba-8176-d344b1028316" />

Negative consumption (fake):
<img width="961" height="720" alt="image" src="https://github.com/user-attachments/assets/d8671ada-3100-4bc7-af12-74811b3f71e0" />