### PR TITLE
Allow comparison-only runs on any active tariff

### DIFF
--- a/src/account_manager.py
+++ b/src/account_manager.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Dict
 import logging
 import config
 from account_info import AccountInfo
-from tariff import Tariff
+from tariff import Tariff, match_known_tariff
 from query_service import QueryService
 from queries import (
     get_terms_version_query,
@@ -80,13 +80,14 @@ class AccountManager:
         if not import_agreement:
             raise Exception("ERROR: No IMPORT meter point found in account data")
 
-        tariff_data = import_agreement.get("tariff")
-        if not tariff_data:
-            raise Exception("ERROR: No tariff information found for the IMPORT meter")
-
+        tariff_data = import_agreement.get("tariff") or {}
         tariff_code = tariff_data.get("tariffCode")
         if not tariff_code:
-            raise Exception("ERROR: No tariff code found for the IMPORT tariff")
+            typename = tariff_data.get("__typename")
+            raise Exception(
+                f"ERROR: No tariff information found for the IMPORT meter"
+                + (f" (GraphQL type: {typename})" if typename else "")
+            )
 
         current_standing_charge = tariff_data.get("standingCharge")
         # A standing charge can be 0.0, so check for None explicitly
@@ -113,9 +114,23 @@ class AccountManager:
         if not self.device_id:
             raise Exception("ERROR: No device ID found for the IMPORT meter")
 
-        matching_tariff_obj = next((tariff for tariff in self.available_tariffs if tariff.is_tariff(tariff_code)), None)
+        matching_tariff_obj = match_known_tariff(tariff_code)
         if matching_tariff_obj is None:
-            raise Exception(f"ERROR: Found no supported tariff object for '{tariff_code}' among available tariffs.")
+            display_name = tariff_data.get("displayName") or tariff_data.get("fullName")
+            matching_tariff_obj = Tariff.unrecognised(
+                tariff_code=tariff_code,
+                product_code=tariff_data.get("productCode"),
+                display_name=display_name,
+            )
+            logger.info(
+                f"Current tariff '{tariff_code}' ({tariff_data.get('__typename')}) is not a known "
+                f"switchable product; running comparison-only as '{matching_tariff_obj.display_name}'."
+            )
+        elif matching_tariff_obj not in self.available_tariffs:
+            logger.info(
+                f"Current tariff '{matching_tariff_obj.id}' is not in TARIFFS config; "
+                "still using it as the comparison baseline."
+            )
 
         # Get consumption for today
         consumption_gql_query = consumption_query.format(

--- a/src/bot_orchestrator.py
+++ b/src/bot_orchestrator.py
@@ -113,6 +113,41 @@ class BotOrchestrator:
 
         return "\n".join(lines)
 
+    def _format_no_switch_message(self, result: ComparisonResult) -> str:
+        current = result.current_tariff_comparison.tariff
+        current_cost = ""
+        if result.current_tariff_comparison.cost_breakdown:
+            current_cost = f" at £{result.current_tariff_comparison.cost_breakdown.total_cost_pounds:.2f}"
+
+        if not current.can_leave:
+            if result.cheapest_tariff is None:
+                return (
+                    f"Comparison only - current tariff ({current.display_name}) cannot be switched "
+                    f"from automatically."
+                )
+            if result.potential_savings > 0:
+                return (
+                    f"Comparison only - staying on {current.display_name}{current_cost}. "
+                    f"Cheapest switchable tariff today is {result.cheapest_tariff.display_name} "
+                    f"(£{result.potential_savings / 100:.2f} cheaper)."
+                )
+            return (
+                f"Comparison only - current tariff {current.display_name}{current_cost} is cheaper "
+                f"than the switchable alternatives today."
+            )
+
+        if result.cheapest_tariff == current:
+            return f"You are already on the cheapest tariff: {current.display_name}{current_cost}"
+
+        if result.cheapest_tariff is None:
+            return "Not switching today - no cheaper switchable tariff was found."
+
+        return (
+            f"Not switching today - savings of (£{result.potential_savings / 100:.2f}) "
+            f"on the cheapest tariff {result.cheapest_tariff.display_name} are below your "
+            f"threshold of £{config.SWITCH_THRESHOLD / 100:.2f}"
+        )
+
     def _compare_and_switch(self) -> None:
         ns = self.notification_service
         welcome_message = f"{'DRY RUN: ' if config.DRY_RUN else ''}Starting comparison of today's costs..."
@@ -134,15 +169,7 @@ class BotOrchestrator:
             else:
                 self._execute_switch(results.cheapest_tariff, account_info)
         else:
-            if results.cheapest_tariff == results.current_tariff_comparison.tariff:
-                message = (f"You are already on the cheapest tariff: "
-                          f"{results.cheapest_tariff.display_name} at "
-                          f"£{results.current_tariff_comparison.cost_breakdown.total_cost_pounds:.2f}")
-            else:
-                message = (f"Not switching today - savings of (£{results.potential_savings / 100:.2f}) "
-                           f"on the cheapest tariff {results.cheapest_tariff.display_name} are below your "
-                           f"threshold of £{config.SWITCH_THRESHOLD / 100:.2f}")
-            ns.send_notification(message)
+            ns.send_notification(self._format_no_switch_message(results))
 
     def _execute_switch(self, target_tariff: Tariff, account_info: AccountInfo) -> None:
         ns = self.notification_service

--- a/src/comparison_engine.py
+++ b/src/comparison_engine.py
@@ -51,10 +51,18 @@ class ComparisonResult:
 
     @property
     def should_switch(self) -> bool:
-        logger.debug(f"cheapest_tariff: {self.cheapest_tariff.display_name}, potential_savings: {self.potential_savings}, SWITCH_THRESHOLD: {config.SWITCH_THRESHOLD}")
-        return (self.cheapest_tariff is not None and
-                self.cheapest_tariff != self.current_tariff_comparison.tariff and
-                self.potential_savings > config.SWITCH_THRESHOLD) # buffer
+        current = self.current_tariff_comparison.tariff
+        cheapest_name = self.cheapest_tariff.display_name if self.cheapest_tariff else None
+        logger.debug(
+            f"cheapest_tariff: {cheapest_name}, potential_savings: {self.potential_savings}, "
+            f"SWITCH_THRESHOLD: {config.SWITCH_THRESHOLD}, can_leave: {current.can_leave}"
+        )
+        return (
+            current.can_leave
+            and self.cheapest_tariff is not None
+            and self.cheapest_tariff != current
+            and self.potential_savings > config.SWITCH_THRESHOLD
+        )
 
     @property
     def all_comparisons(self) -> List[TariffComparison]:
@@ -77,7 +85,11 @@ class ComparisonEngine:
         for tariff in available_tariffs:
             if tariff == account_info.current_tariff:
                 continue
-            comparison = self._compare_tariff(tariff, account_info)
+            try:
+                comparison = self._compare_tariff(tariff, account_info)
+            except Exception as e:
+                logger.warning(f"Error finding prices for tariff: {tariff.id}. {e}")
+                comparison = TariffComparison(tariff=tariff, cost_breakdown=None, error=str(e))
             alternative_comparisons.append(comparison)
 
         logger.debug(f"Tariff comparison results - {alternative_comparisons}")

--- a/src/queries.py
+++ b/src/queries.py
@@ -55,14 +55,56 @@ account_query = """query{{
             direction
         }}
         tariff {{
+            __typename
             ... on HalfHourlyTariff {{
                 id
+                displayName
+                fullName
                 productCode
                 tariffCode
-                productCode
                 standingCharge
-                }}
             }}
+            ... on StandardTariff {{
+                id
+                displayName
+                fullName
+                productCode
+                tariffCode
+                standingCharge
+            }}
+            ... on DayNightTariff {{
+                id
+                displayName
+                fullName
+                productCode
+                tariffCode
+                standingCharge
+            }}
+            ... on ThreeRateTariff {{
+                id
+                displayName
+                fullName
+                productCode
+                tariffCode
+                standingCharge
+            }}
+            ... on FourRateEvTariff {{
+                id
+                displayName
+                fullName
+                productCode
+                tariffCode
+                standingCharge
+            }}
+            ... on PrepayTariff {{
+                id
+                displayName
+                fullName
+                productCode
+                tariffCode
+                standingCharge
+            }}
+        }}
         }}
     }}
 }}"""

--- a/src/tariff.py
+++ b/src/tariff.py
@@ -3,7 +3,8 @@ import re
 class Tariff:
     def __init__(self,
                  id: str, display_name: str, api_display_name: str, tariff_code_matcher: str,
-                 url_tariff_name: str, switchable: bool, product_code: str = None):
+                 url_tariff_name: str, switchable: bool, product_code: str = None,
+                 can_leave: bool = True):
         self.id = id  # Represents the unique identifier for the tariff.
         self.display_name = display_name  # The user-friendly name of the tariff for display purposes.
         self.api_display_name = api_display_name  # The name used for API interactions with the tariff.
@@ -11,6 +12,23 @@ class Tariff:
         self.url_tariff_name = url_tariff_name  # The tariff name formatted for use in URLs.
         self.switchable = switchable  # Whether this tariff can be switched to or not
         self.product_code = product_code # Product code used in API e.g. "GO-VAR-22-10-14"
+        # Whether the bot is allowed to switch away from this tariff (False for locked/unknown products).
+        self.can_leave = can_leave
+
+    @classmethod
+    def unrecognised(cls, tariff_code: str, product_code: str = None, display_name: str = None) -> "Tariff":
+        """Placeholder for a live tariff we can cost from telemetry but not switch to or from."""
+        label = display_name or product_code or tariff_code
+        return cls(
+            id=f"current:{tariff_code}",
+            display_name=label,
+            api_display_name=label,
+            tariff_code_matcher=re.escape(tariff_code),
+            url_tariff_name="",
+            switchable=False,
+            product_code=product_code,
+            can_leave=False,
+        )
 
     def is_tariff(self, current_tariff_name: str) -> bool:
         """Check if the given tariff name matches the tariff code matcher using regex."""
@@ -26,13 +44,21 @@ class Tariff:
         return hash(self.id)
 
     def __str__(self):
-        return f"Tariff(id={self.id}, display_name={self.display_name}, api_display_name={self.api_display_name}, tariff_code_matcher={self.tariff_code_matcher}, url_tariff_name={self.url_tariff_name}, switchable={self.switchable}, product_code={self.product_code})"
+        return (
+            f"Tariff(id={self.id}, display_name={self.display_name}, api_display_name={self.api_display_name}, "
+            f"tariff_code_matcher={self.tariff_code_matcher}, url_tariff_name={self.url_tariff_name}, "
+            f"switchable={self.switchable}, can_leave={self.can_leave}, product_code={self.product_code})"
+        )
 
 
 TARIFFS = [
     Tariff("go", "Octopus Go", "Octopus Go", r"-go-var-", "go", True), # Octopus Go (Variable)
-    Tariff("go-fix-12m", "Octopus Go 12M Fixed", "Octopus Go 12M Fixed", r"-go-fix-", "go", True),
+    Tariff("go-fix-12m", "Octopus Go 12M Fixed", "Octopus Go 12M Fixed", r"-go-fix-", "go", True, can_leave=False),
     Tariff("agile", "Agile Octopus", "Agile Octopus", r"-agile-", "agile", True), # Octopus Agile
     Tariff("cosy", "Cosy Octopus", "Cosy Octopus", r"-cosy-(?!.*fix)", r"cosy-octopus", True), # Octopus Cosy (Variable is the default so don't match anything with 'fix' in the name)
     Tariff("flexible", "Flexible Octopus", "Flexible Octopus", r"(?<!go-)var", "", False) # Flexible Octopus
 ]
+
+
+def match_known_tariff(tariff_code: str):
+    return next((tariff for tariff in TARIFFS if tariff.is_tariff(tariff_code)), None)


### PR DESCRIPTION
## Allow people on non smart tariffs to run the bot and see today's costs vs switchable alternatives
### Summary
**Current:**
Fixed and other non-smart active tariffs (e.g. Octopus 12M Fixed) return empty `HalfHourlyTariff`, and the bot exits with "No tariff information found".

**Changed:**
- Add support for any active tariff type (`StandardTariff`, `DayNightTariff`, `ThreeRateTariff`, `FourRateEvTariff`, `PrepayTariff`).
- Unknown tariffs (and go-fixed) have a new property to indicate they cannot be switched from (`can_leave=False`).
- When one of those is detected, switch to comparison only mode (aka dry run). 

